### PR TITLE
アカウント画面でお便りみ取得時にエラーになっていたためデータ0件時の処理を追加

### DIFF
--- a/lib/romasaga/common/rs_strings.dart
+++ b/lib/romasaga/common/rs_strings.dart
@@ -71,6 +71,7 @@ class RSStrings {
 
   static const String accountLetterUpdateLabel = 'お便り';
   static const String accountLetterLatestLabel = '最新:';
+  static const String accountLetterEmptyLabel = 'ー';
   static const String accountLetterUpdateDialogMessage = '新しくサーバーに登録されたお便り情報を取得します。\nよろしいですか？';
   static const String accountLetterUpdateDialogSuccessMessage = '最新のお便り情報を取得しました。';
 

--- a/lib/romasaga/common/rs_strings.dart
+++ b/lib/romasaga/common/rs_strings.dart
@@ -65,6 +65,7 @@ class RSStrings {
 
   static const String accountStageUpdateLabel = 'ステージ';
   static const String accountStageLatestLabel = '最新:';
+  static const String accountStageEmptyLabel = 'ー';
   static const String accountStageUpdateDialogMessage = '現在のステージ情報を全て削除してサーバーから再取得します。\nよろしいですか？';
   static const String accountStageUpdateDialogSuccessMessage = '最新のステージ情報を取得しました。';
 

--- a/lib/romasaga/data/letter_repository.dart
+++ b/lib/romasaga/data/letter_repository.dart
@@ -45,7 +45,11 @@ class LetterRepository {
 
   Future<String> getLatestLetterName() async {
     final letters = await _dao.findAll();
-    final latestLetter = letters.last;
-    return '${latestLetter.year}${RSStrings.letterYearLabel}${latestLetter.month}${RSStrings.letterMonthLabel} ${latestLetter.shortTitle}';
+    if (letters.isEmpty) {
+      return RSStrings.accountLetterEmptyLabel;
+    } else {
+      final latestLetter = letters.last;
+      return '${latestLetter.year}${RSStrings.letterYearLabel}${latestLetter.month}${RSStrings.letterMonthLabel} ${latestLetter.shortTitle}';
+    }
   }
 }

--- a/lib/romasaga/data/stage_repository.dart
+++ b/lib/romasaga/data/stage_repository.dart
@@ -1,3 +1,5 @@
+import 'package:rsapp/romasaga/common/rs_strings.dart';
+
 import 'local/stage_dao.dart';
 import 'remote/stage_api.dart';
 
@@ -46,6 +48,10 @@ class StageRepository {
 
   Future<String> getLatestStageName() async {
     final stages = await _dao.findAll();
-    return stages.first.name;
+    if (stages.isEmpty) {
+      return RSStrings.accountStageEmptyLabel;
+    } else {
+      return stages?.first?.name;
+    }
   }
 }

--- a/lib/romasaga/ui/account/account_page.dart
+++ b/lib/romasaga/ui/account/account_page.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 
 import 'account_page_view_model.dart';
 
-import '../../common/rs_colors.dart';
 import '../../common/rs_strings.dart';
 
 class AccountPage extends StatelessWidget {
@@ -44,8 +43,7 @@ class AccountPage extends StatelessWidget {
   }
 
   Widget _loadLoginView(BuildContext context, bool loggedIn) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
+    return ListView(
       children: <Widget>[
         _rowAccountInfo(),
         Divider(color: Theme.of(context).accentColor),
@@ -98,10 +96,11 @@ class AccountPage extends StatelessWidget {
     return Consumer<AccountPageViewModel>(
       builder: (context, viewModel, child) {
         return Padding(
-          padding: const EdgeInsets.only(top: 32.0),
+          padding: const EdgeInsets.all(32.0),
           child: RaisedButton(
+            padding: const EdgeInsets.only(top: 4.0, bottom: 4.0),
             color: Theme.of(context).accentColor,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
             child: Text(RSStrings.accountLoginWithGoogle),
             onPressed: () {
               if (viewModel.nowLoading) return;

--- a/lib/romasaga/ui/characters/char_list_view_model.dart
+++ b/lib/romasaga/ui/characters/char_list_view_model.dart
@@ -102,7 +102,7 @@ class CharListViewModel extends foundation.ChangeNotifier {
     RSLogger.d("登録ステータスをロードします。");
     final myStatuses = await _myStatusRepository.findAll();
 
-    RSLogger.d("登録ステータスが完了しました。");
+    RSLogger.d("登録ステータスのロードが完了しました。");
     if (myStatuses.isNotEmpty) {
       for (var status in myStatuses) {
         RSLogger.d("ステのid=${status.id}");


### PR DESCRIPTION
バグ修正

## 事象
アプリをインストール後、アカウント画面に遷移するとプログレスバーが回ったままになる

## 原因
お便り情報をLocalDBから取得した際にデータが0件の考慮をしていないため  
（ステージ情報も同じ事象が発生して修正したのだがその横並びをしていなかった）

## 対応内容
お便り情報をLocalDBから取得した際にデータが0件だったら「ー」を表示するよう修正