### PR TITLE
アカウント画面のログアウトボタンの横幅など修正

### DIFF
--- a/lib/romasaga/common/rs_strings.dart
+++ b/lib/romasaga/common/rs_strings.dart
@@ -49,8 +49,7 @@ class RSStrings {
   static const String accountNotLoginEmailLabel = '未ログイン';
   static const String accountNotLoginNameLabel = 'ー';
   static const String accountLoginWithGoogle = 'Googleアカウントでログイン';
-
-  static const String accountLogoutTitle = 'ログアウト';
+  static const String accountLogoutTitle = 'Googleアカウントからログアウト';
   static const String accountLogoutDialogMessage = 'ログアウトしてもよろしいですか？';
   static const String accountLogoutSuccessMessage = 'ログアウトが完了しました。';
 

--- a/lib/romasaga/ui/account/account_page.dart
+++ b/lib/romasaga/ui/account/account_page.dart
@@ -66,9 +66,11 @@ class AccountPage extends StatelessWidget {
   Widget _rowLogoutButton() {
     return Consumer<AccountPageViewModel>(builder: (context, viewModel, child) {
       return Padding(
-        padding: const EdgeInsets.only(top: 32.0),
+        padding: const EdgeInsets.all(32.0),
         child: OutlineButton(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+          padding: const EdgeInsets.only(top: 4.0, bottom: 4.0),
+          color: Theme.of(context).accentColor,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
           child: Text(RSStrings.accountLogoutTitle),
           onPressed: () async {
             await AwesomeDialog(


### PR DESCRIPTION
issue #9 

Googleアカウントからのログアウトボタンが間延びしていたのでログインボタンと同形式に修正。  
なお、ログインするとデータのバックアップや復元ができるので推奨するが、ログアウトは特にする必要がないのでOutlineボタンで作っているところは変えていない。