### PR TITLE
fix: キャラ詳細画面でアイコンをサーバーから再取得した際に一覧に戻ってもアイコンが更新されなかったバグを修正

### DIFF
--- a/lib/romasaga/model/character.dart
+++ b/lib/romasaga/model/character.dart
@@ -1,7 +1,7 @@
 import 'package:rsapp/romasaga/model/attribute.dart';
-import 'package:rsapp/romasaga/model/weapon.dart';
 import 'package:rsapp/romasaga/model/status.dart';
 import 'package:rsapp/romasaga/model/style.dart';
+import 'package:rsapp/romasaga/model/weapon.dart';
 
 class Character {
   Character(
@@ -30,17 +30,22 @@ class Character {
   MyStatus myStatus;
 
   WeaponType get weaponType => weapon.type;
+
   WeaponCategory get weaponCategory => weapon.category;
+
   Style get selectedStyle => getStyle(selectedStyleRank);
 
-  void addStyles(List<Style> styles) {
-    for (var style in styles) {
-      addStyle(style);
-    }
+  void addStyles(List<Style> argStyles) {
+    styles.addAll(argStyles);
   }
 
   void addStyle(Style style) {
     styles.add(style);
+  }
+
+  void refreshStyles(List<Style> argStyles) {
+    styles.clear();
+    styles.addAll(argStyles);
   }
 
   Style getStyle(String rank) {

--- a/lib/romasaga/ui/characters/char_list_page.dart
+++ b/lib/romasaga/ui/characters/char_list_page.dart
@@ -116,7 +116,7 @@ class CharListPage extends StatelessWidget {
     return ListView.builder(itemBuilder: (context, index) {
       if (index < characters.length) {
         return CharListRowItem(characters[index], refreshListener: () async {
-          await viewModel.refreshMyStatuses();
+          await viewModel.refresh();
         });
       }
       return null;
@@ -142,7 +142,7 @@ class CharListPage extends StatelessWidget {
     return ListView.builder(itemBuilder: (context, index) {
       if (index < characters.length) {
         return CharListRowItem(characters[index], refreshListener: () async {
-          await viewModel.refreshMyStatuses();
+          await viewModel.refresh();
         });
       }
       return null;
@@ -170,7 +170,7 @@ class CharListPage extends StatelessWidget {
 
       if (index < characters.length) {
         return CharListRowItem(characters[index], refreshListener: () async {
-          await viewModel.refreshMyStatuses();
+          await viewModel.refresh();
         });
       }
       return null;
@@ -185,7 +185,7 @@ class CharListPage extends StatelessWidget {
 
       if (index < characters.length) {
         return CharListRowItem(characters[index], refreshListener: () async {
-          await viewModel.refreshMyStatuses();
+          await viewModel.refresh();
         });
       }
       return null;

--- a/lib/romasaga/ui/characters/char_list_view_model.dart
+++ b/lib/romasaga/ui/characters/char_list_view_model.dart
@@ -1,7 +1,7 @@
+import 'package:rsapp/romasaga/common/rs_logger.dart';
 import 'package:rsapp/romasaga/data/character_repository.dart';
 import 'package:rsapp/romasaga/data/my_status_repository.dart';
 import 'package:rsapp/romasaga/model/character.dart';
-import 'package:rsapp/romasaga/common/rs_logger.dart';
 import 'package:rsapp/romasaga/ui/change_notifier_view_model.dart';
 
 class CharListViewModel extends ChangeNotifierViewModel {
@@ -34,8 +34,16 @@ class CharListViewModel extends ChangeNotifierViewModel {
     );
   }
 
-  List<Character> findAll() {
-    return _characters;
+  ///
+  /// キャラ情報を更新する
+  ///
+  Future<void> refresh() async {
+    RSLogger.d("キャラ情報を更新します");
+    _characters = await _characterRepository.findAll();
+    await _loadMyStatuses();
+    orderBy(OrderType.status);
+
+    notifyListeners();
   }
 
   List<Character> findFavorite() {
@@ -71,15 +79,6 @@ class CharListViewModel extends ChangeNotifierViewModel {
         break;
     }
     selectedOrderType = order;
-    notifyListeners();
-  }
-
-  ///
-  /// ステータス情報を更新する。
-  /// 詳細画面から戻ってきたときに使う。
-  ///
-  Future<void> refreshMyStatuses() async {
-    await _loadMyStatuses();
     notifyListeners();
   }
 

--- a/lib/romasaga/ui/detail/char_detail_page.dart
+++ b/lib/romasaga/ui/detail/char_detail_page.dart
@@ -67,13 +67,13 @@ class CharDetailPage extends StatelessWidget {
           child: ListView(
             children: <Widget>[
               _contentCharacterOverview(context),
-              SizedBox(height: 16.0),
+              const SizedBox(height: 16.0),
               _contentStatus(context),
-              SizedBox(height: 16.0),
+              const SizedBox(height: 16.0),
               _contentsStage(context),
-              SizedBox(height: 24.0),
+              const SizedBox(height: 24.0),
               _contentsEachStyleStatus(context),
-              SizedBox(height: 16.0),
+              const SizedBox(height: 16.0),
             ],
           ),
         ),
@@ -158,7 +158,8 @@ class CharDetailPage extends StatelessWidget {
       children: <Widget>[
         _createWeaponIcon(context, viewModel.character.weaponType),
         if (viewModel.character.weaponCategory != WeaponCategory.rod) _createWeaponCategoryIcon(context, viewModel.character.weaponCategory),
-        if (viewModel.haveAttribute) for (final attribute in viewModel.character.attributes) _createAttributeIcon(context, attribute),
+        if (viewModel.haveAttribute)
+          for (final attribute in viewModel.character.attributes) _createAttributeIcon(context, attribute),
       ],
     );
   }

--- a/lib/romasaga/ui/detail/char_detail_view_model.dart
+++ b/lib/romasaga/ui/detail/char_detail_view_model.dart
@@ -176,6 +176,11 @@ class CharDetailViewModel extends ChangeNotifierViewModel {
       final isSelectedIcon = _selectedStyle.rank == character.selectedStyleRank;
       RSLogger.d('アイコンをサーバーから再取得します。（このアイコンをデフォルトにしているか？ $isSelectedIcon)');
       await _characterRepository.refreshIcon(_selectedStyle, isSelectedIcon);
+
+      RSLogger.d('アイコン情報をキャラ情報に反映します。');
+      final styles = await _characterRepository.findStyles(character.id);
+      character.refreshStyles(styles);
+
       return true;
     } catch (e) {
       RSLogger.e('アイコン更新処理でエラーが発生しました', e);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: rsapp
 description: Romancing Saga RS Status Management application.
 
-version: 1.6.1+6
+version: 1.6.1+7
 
 environment:
   sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
issue #34 

キャラ一覧に戻った際、今まではステータスしか更新していなかったがキャラ情報を更新するように修正した。