### PR TITLE
fix: 追加漏れしていた作品がありエラーになっていたので対応

### DIFF
--- a/lib/romasaga/common/rs_strings.dart
+++ b/lib/romasaga/common/rs_strings.dart
@@ -162,5 +162,6 @@ class RSStrings {
   static const String productUnLimited = 'アンリミテッド・サガ';
   static const String productEmperorsSaga = 'エンペラーズサガ';
   static const String productRomaSagaRS = 'ロマンシング・サガRS';
+  static const String productSaga = '魔界塔士 Sa・Ga';
   static const String productSaga2 = 'Sa・Ga2 秘宝伝説';
 }

--- a/lib/romasaga/model/production.dart
+++ b/lib/romasaga/model/production.dart
@@ -26,6 +26,8 @@ class Production {
         return ProductionType.emperorssaga;
       case RSStrings.productRomaSagaRS:
         return ProductionType.romasagaRS;
+      case RSStrings.productSaga:
+        return ProductionType.saga1;
       case RSStrings.productSaga2:
         return ProductionType.saga2;
       default:
@@ -44,5 +46,6 @@ enum ProductionType {
   unlimited,
   emperorssaga,
   romasagaRS,
+  saga1,
   saga2,
 }

--- a/lib/romasaga/ui/widget/rs_dialog.dart
+++ b/lib/romasaga/ui/widget/rs_dialog.dart
@@ -98,7 +98,7 @@ class RSSimpleDialog {
       context: context,
       builder: (_) {
         return AlertDialog(
-          content: const Text(RSStrings.characterDetailChangeStyleIconDialogMessage),
+          content: Text(message),
           actions: <Widget>[
             FlatButton(
               child: const Text(RSStrings.simpleDialogCancelLabel),

--- a/lib/romasaga/ui/widget/rs_icon.dart
+++ b/lib/romasaga/ui/widget/rs_icon.dart
@@ -391,6 +391,8 @@ class ProductionLogo extends StatelessWidget {
         return 'res/logos/EmperorsSaga.jpg';
       case ProductionType.romasagaRS:
         return 'res/logos/RomasagaRS.jpg';
+      case ProductionType.saga1:
+        return 'res/logos/Saga.jpg';
       case ProductionType.saga2:
         return 'res/logos/Saga2.jpg';
       default:


### PR DESCRIPTION
issue #40  

2020年9月のGB版Sagaのキャラを追加した際に、作品検索機能にSaga2は登録していたがSagaを登録しておらず内部エラーになっていた。このPRで未登録の作品を追加